### PR TITLE
S UI t 81 스터디 참가 취소하기

### DIFF
--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/controller/ParticipantController.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/controller/ParticipantController.java
@@ -24,5 +24,9 @@ public class ParticipantController {
         return ResponseEntity.ok(new Message(StatusCode.OK));
     }
 
-
+    @PostMapping("/suiteroom/attend/cancel")
+    public ResponseEntity<Message> cancelSuiteRoom(@RequestBody Map<String, Long> suiteRoomId) {
+        participantService.removeParticipant(suiteRoomId.get("suiteRoomId"), getSuiteAuthorizer());
+        return ResponseEntity.ok(new Message(StatusCode.OK));
+    }
 }

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/controller/ParticipantController.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/controller/ParticipantController.java
@@ -23,4 +23,6 @@ public class ParticipantController {
         participantService.addParticipant(suiteRoomId.get("suiteRoomId"), getSuiteAuthorizer());
         return ResponseEntity.ok(new Message(StatusCode.OK));
     }
+
+
 }

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/handler/StatusCode.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/handler/StatusCode.java
@@ -10,6 +10,7 @@ public enum StatusCode {
     DORMANT_ACCOUNT(423, "이 계정은 휴먼 계정입니다.", HttpStatus.LOCKED),
     ALREADY_EXISTS_SUITEROOM(400, "이미 존재하는 스위트룸입니다.", HttpStatus.BAD_REQUEST),
     ALREADY_EXISTS_PARTICIPANT(400, "이미 참여중 입니다.", HttpStatus.BAD_REQUEST),
+    CAN_NOT_CALCEL_SUITEROOM(400, "스위트룸 참가 취소를 할 수 없습니다.", HttpStatus.BAD_REQUEST),
     NOT_DELETE_SUITE_ROOM(400, "시작된 스터디는 삭제가 불가능합니다.", HttpStatus.BAD_REQUEST),
     USERNAME_OR_PASSWORD_NOT_FOUND (400, "아이디 또는 비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
     SUITE_ROOM_NOT_FOUND (400, "존재하지 않는 스위트룸 아이디입니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/repository/ParticipantRepository.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/repository/ParticipantRepository.java
@@ -13,5 +13,6 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
 
     Long countBySuiteRoom_SuiteRoomId(Long suiteRoomId);
 
+    void deleteBySuiteRoom_SuiteRoomIdAndMemberId(Long suiteRoomId, Long memberId);
     Boolean existsBySuiteRoom_SuiteRoomIdAndMemberIdAndIsHost(Long suiteRoomId, Long memberId, boolean ishost);
 }

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/service/ParticipantService.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/service/ParticipantService.java
@@ -5,4 +5,5 @@ import com.suite.suite_suite_room_service.suiteRoom.security.dto.AuthorizerDto;
 public interface ParticipantService {
 
     void addParticipant(Long suiteRoomId, AuthorizerDto authorizerDto);
+    void removeParticipant(Long suiteRoomId, AuthorizerDto authorizerDto);
 }

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/service/ParticipantServiceImpl.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/service/ParticipantServiceImpl.java
@@ -10,6 +10,7 @@ import com.suite.suite_suite_room_service.suiteRoom.repository.SuiteRoomReposito
 import com.suite.suite_suite_room_service.suiteRoom.security.dto.AuthorizerDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +19,7 @@ public class ParticipantServiceImpl implements ParticipantService{
     private final ParticipantRepository participantRepository;
 
     @Override
+    @Transactional
     public void addParticipant(Long suiteRoomId, AuthorizerDto authorizerDto) {
         SuiteRoom suiteRoom = suiteRoomRepository.findBySuiteRoomId(suiteRoomId).orElseThrow(
                 () -> new CustomException(StatusCode.NOT_FOUND));
@@ -34,6 +36,7 @@ public class ParticipantServiceImpl implements ParticipantService{
     }
 
     @Override
+    @Transactional
     public void removeParticipant(Long suiteRoomId, AuthorizerDto authorizerDto) {
         Participant participant = participantRepository.findBySuiteRoom_SuiteRoomIdAndMemberId(suiteRoomId, authorizerDto.getMemberId()).orElseThrow(
                 () -> new CustomException(StatusCode.FAILED_REQUEST)

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/service/ParticipantServiceImpl.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/service/ParticipantServiceImpl.java
@@ -33,4 +33,16 @@ public class ParticipantServiceImpl implements ParticipantService{
         participantRepository.save(participant);
     }
 
+    @Override
+    public void removeParticipant(Long suiteRoomId, AuthorizerDto authorizerDto) {
+        Participant participant = participantRepository.findBySuiteRoom_SuiteRoomIdAndMemberId(suiteRoomId, authorizerDto.getMemberId()).orElseThrow(
+                () -> new CustomException(StatusCode.FAILED_REQUEST)
+        );
+
+        if(participant.getStatus().equals(SuiteStatus.READY))
+            System.out.println("kafka");
+
+        participantRepository.deleteBySuiteRoom_SuiteRoomIdAndMemberId(suiteRoomId, authorizerDto.getMemberId());
+    }
+
 }

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/service/ParticipantServiceImpl.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/service/ParticipantServiceImpl.java
@@ -39,12 +39,12 @@ public class ParticipantServiceImpl implements ParticipantService{
     @Transactional
     public void removeParticipant(Long suiteRoomId, AuthorizerDto authorizerDto) {
         Participant participant = participantRepository.findBySuiteRoom_SuiteRoomIdAndMemberId(suiteRoomId, authorizerDto.getMemberId()).orElseThrow(
-                () -> new CustomException(StatusCode.FAILED_REQUEST)
-        );
+                () -> new CustomException(StatusCode.FAILED_REQUEST));
 
         if(participant.getStatus().equals(SuiteStatus.READY))
             System.out.println("kafka");
-
+        if(participant.getIsHost())
+            throw new CustomException(StatusCode.CAN_NOT_CALCEL_SUITEROOM);
         participantRepository.deleteBySuiteRoom_SuiteRoomIdAndMemberId(suiteRoomId, authorizerDto.getMemberId());
     }
 

--- a/src/test/java/com/suite/suite_suite_room_service/suiteRoom/controller/ParticipantControllerTest.java
+++ b/src/test/java/com/suite/suite_suite_room_service/suiteRoom/controller/ParticipantControllerTest.java
@@ -6,9 +6,12 @@ import com.suite.suite_suite_room_service.suiteRoom.dto.ReqSuiteRoomDto;
 import com.suite.suite_suite_room_service.suiteRoom.entity.SuiteRoom;
 import com.suite.suite_suite_room_service.suiteRoom.mockEntity.MockAuthorizer;
 import com.suite.suite_suite_room_service.suiteRoom.mockEntity.MockSuiteRoom;
+import com.suite.suite_suite_room_service.suiteRoom.repository.SuiteRoomRepository;
+import com.suite.suite_suite_room_service.suiteRoom.security.dto.AuthorizerDto;
 import com.suite.suite_suite_room_service.suiteRoom.service.ParticipantServiceImpl;
 import com.suite.suite_suite_room_service.suiteRoom.service.SuiteRoomServiceImpl;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,16 +37,21 @@ class ParticipantControllerTest {
     @Autowired private MockMvc mockMvc;
     @Autowired private ParticipantServiceImpl participantService;
     @Autowired private SuiteRoomServiceImpl suiteRoomService;
+    @Autowired private SuiteRoomRepository suiteRoomRepository;
 
     public static final String YH_JWT = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJsb3BhaG4yQGdtYWlsLmNvbSIsIklEIjoiMSIsIk5BTUUiOiLrsJjsmIHtmZgiLCJOSUNLTkFNRSI6Imh3YW55OTkiLCJBQ0NPVU5UU1RBVFVTIjoiQUNUSVZBVEUiLCJST0xFIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjkwODE0MDk5LCJleHAiOjE2OTE0MTg4OTl9.xlbiPnD366KP49g5v6X_F4yEZRvu6rbf3ph6j-AWxs8";
     public static final String DR_JWT = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ6eHo0NjQxQGdtYWlsLmNvbSIsIklEIjoiMiIsIk5BTUUiOiLquYDrjIDtmIQiLCJOSUNLTkFNRSI6IkRhcnJlbiIsIkFDQ09VTlRTVEFUVVMiOiJBQ1RJVkFURSIsIlJPTEUiOiJST0xFX1VTRVIiLCJpYXQiOjE2OTA4MTQxMzUsImV4cCI6MTY5MTQxODkzNX0.ob5s7qQxdALJHpxb28pyYFiAqdeifGKfxtGx9MD3KQ0";
+
+    @BeforeEach
+    public void setUp() {
+        ReqSuiteRoomDto reqSuiteRoomDto = MockSuiteRoom.getMockSuiteRoom("title2", true);
+        suiteRoomService.createSuiteRoom(reqSuiteRoomDto, MockAuthorizer.getMockAuthorizer("hwany", 1L));
+    }
 
     @Test
     @DisplayName("스위트룸 참가하기")
     public void joinSuiteRoom() throws Exception {
         //given
-        ReqSuiteRoomDto reqSuiteRoomDto = MockSuiteRoom.getMockSuiteRoom("title2", true);
-        suiteRoomService.createSuiteRoom(reqSuiteRoomDto, MockAuthorizer.getMockAuthorizer("hwany"));
         Map<String, Long> suiteRoomId = new HashMap<String, Long>();
         suiteRoomId.put("suiteRoomId", Long.parseLong("1"));
         String body = mapper.writeValueAsString(suiteRoomId);
@@ -60,10 +68,10 @@ class ParticipantControllerTest {
     @DisplayName("스위트룸 참가 취소")
     public void cancelSuiteRoom() throws Exception {
         //given
-        ReqSuiteRoomDto reqSuiteRoomDto = MockSuiteRoom.getMockSuiteRoom("title2", true);
-        suiteRoomService.createSuiteRoom(reqSuiteRoomDto, MockAuthorizer.getMockAuthorizer("hwany"));
+        AuthorizerDto participant = MockAuthorizer.getMockAuthorizer("Darren", 2L);
+        participantService.addParticipant(1L, participant);
         Map<String, Long> suiteRoomId = new HashMap<String, Long>();
-        suiteRoomId.put("suiteRoomId", Long.parseLong("1"));
+        suiteRoomId.put("suiteRoomId", 1L);
         String body = mapper.writeValueAsString(suiteRoomId);
         //when
         String responseBody = postRequest("/suite/suiteroom/attend/cancel", DR_JWT, body);

--- a/src/test/java/com/suite/suite_suite_room_service/suiteRoom/controller/ParticipantControllerTest.java
+++ b/src/test/java/com/suite/suite_suite_room_service/suiteRoom/controller/ParticipantControllerTest.java
@@ -56,6 +56,24 @@ class ParticipantControllerTest {
         );
     }
 
+    @Test
+    @DisplayName("스위트룸 참가 취소")
+    public void cancelSuiteRoom() throws Exception {
+        //given
+        ReqSuiteRoomDto reqSuiteRoomDto = MockSuiteRoom.getMockSuiteRoom("title2", true);
+        suiteRoomService.createSuiteRoom(reqSuiteRoomDto, MockAuthorizer.getMockAuthorizer("hwany"));
+        Map<String, Long> suiteRoomId = new HashMap<String, Long>();
+        suiteRoomId.put("suiteRoomId", Long.parseLong("1"));
+        String body = mapper.writeValueAsString(suiteRoomId);
+        //when
+        String responseBody = postRequest("/suite/suiteroom/attend/cancel", DR_JWT, body);
+        Message message = mapper.readValue(responseBody, Message.class);
+        //then
+        Assertions.assertAll(
+                () -> assertThat(message.getStatusCode()).isEqualTo(200)
+        );
+    }
+
 
 
     private String postRequest(String url, String jwt, String body) throws Exception {

--- a/src/test/java/com/suite/suite_suite_room_service/suiteRoom/controller/SuiteRoomControllerTest.java
+++ b/src/test/java/com/suite/suite_suite_room_service/suiteRoom/controller/SuiteRoomControllerTest.java
@@ -62,7 +62,7 @@ class SuiteRoomControllerTest {
         //given
         final String url = "/suite/suiteroom/update";
         ReqSuiteRoomDto reqSuiteRoomDto = MockSuiteRoom.getMockSuiteRoom("title2", true);
-        suiteRoomService.createSuiteRoom(reqSuiteRoomDto, MockAuthorizer.getMockAuthorizer("hwany"));
+        suiteRoomService.createSuiteRoom(reqSuiteRoomDto, MockAuthorizer.getMockAuthorizer("hwany", 1L));
         String body = mapper.writeValueAsString(ReqUpdateSuiteRoomDto.builder()
                 .suiteRoomId(Long.parseLong("1"))
                 .content("updated content")
@@ -84,10 +84,10 @@ class SuiteRoomControllerTest {
 
         ReqSuiteRoomDto reqSuiteRoomDto1 = MockSuiteRoom.getMockSuiteRoom("hwany", true);
         ReqSuiteRoomDto reqSuiteRoomDto2 = MockSuiteRoom.getMockSuiteRoom("mini", true);
-        suiteRoomService.createSuiteRoom(reqSuiteRoomDto1, MockAuthorizer.getMockAuthorizer("hwany"));
-        suiteRoomService.createSuiteRoom(reqSuiteRoomDto2, MockAuthorizer.getMockAuthorizer("hwany"));
+        suiteRoomService.createSuiteRoom(reqSuiteRoomDto1, MockAuthorizer.getMockAuthorizer("hwany", 1L));
+        suiteRoomService.createSuiteRoom(reqSuiteRoomDto2, MockAuthorizer.getMockAuthorizer("hwany", 1L));
 
-        List<ResSuiteRoomDto> resService = suiteRoomService.getAllSuiteRooms(MockAuthorizer.getMockAuthorizer("hwany"));
+        List<ResSuiteRoomDto> resService = suiteRoomService.getAllSuiteRooms(MockAuthorizer.getMockAuthorizer("hwany", 1L));
         //when
         String responseBody = getRequest(url, YH_JWT);
         Message message = mapper.readValue(responseBody, Message.class);
@@ -111,8 +111,8 @@ class SuiteRoomControllerTest {
         final Long expectedSuiteRoomId = 1L;
         ReqSuiteRoomDto reqSuiteRoomDto1 = MockSuiteRoom.getMockSuiteRoom("hwany", true);
         ReqSuiteRoomDto reqSuiteRoomDto2 = MockSuiteRoom.getMockSuiteRoom("mini", true);
-        AuthorizerDto mockAuthorizer1 = MockAuthorizer.getMockAuthorizer("hwany");
-        AuthorizerDto mockAuthorizer2 = MockAuthorizer.getMockAuthorizer("mini");
+        AuthorizerDto mockAuthorizer1 = MockAuthorizer.getMockAuthorizer("hwany", 1L);
+        AuthorizerDto mockAuthorizer2 = MockAuthorizer.getMockAuthorizer("mini", 2L);
         suiteRoomService.createSuiteRoom(reqSuiteRoomDto1, mockAuthorizer1);
         suiteRoomService.createSuiteRoom(reqSuiteRoomDto2, mockAuthorizer2);
 
@@ -140,7 +140,7 @@ class SuiteRoomControllerTest {
         //given
         final String url = "/suite/suiteroom/delete/1";
         ReqSuiteRoomDto reqSuiteRoomDto = MockSuiteRoom.getMockSuiteRoom("title2", true);
-        suiteRoomService.createSuiteRoom(reqSuiteRoomDto, MockAuthorizer.getMockAuthorizer("hwany"));
+        suiteRoomService.createSuiteRoom(reqSuiteRoomDto, MockAuthorizer.getMockAuthorizer("hwany", 1L));
         //when
         String responseBody = deleteRequest(url, YH_JWT);
         Message message = mapper.readValue(responseBody, Message.class);

--- a/src/test/java/com/suite/suite_suite_room_service/suiteRoom/mockEntity/MockAuthorizer.java
+++ b/src/test/java/com/suite/suite_suite_room_service/suiteRoom/mockEntity/MockAuthorizer.java
@@ -3,9 +3,9 @@ package com.suite.suite_suite_room_service.suiteRoom.mockEntity;
 import com.suite.suite_suite_room_service.suiteRoom.security.dto.AuthorizerDto;
 
 public class MockAuthorizer {
-    public static AuthorizerDto getMockAuthorizer(String name) {
+    public static AuthorizerDto getMockAuthorizer(String name, Long memberId) {
         return AuthorizerDto.builder()
-                .memberId(Long.parseLong("1"))
+                .memberId(memberId)
                 .accountStatus("ACTIVIATE")
                 .name(name)
                 .nickName("Darren")

--- a/src/test/java/com/suite/suite_suite_room_service/suiteRoom/service/ParticipantServiceImplTest.java
+++ b/src/test/java/com/suite/suite_suite_room_service/suiteRoom/service/ParticipantServiceImplTest.java
@@ -47,7 +47,7 @@ class ParticipantServiceImplTest {
     public void addParticipant() {
         //given
         Long targetSuiteRoomId = 1L;
-        AuthorizerDto authorizerDto = MockAuthorizer.getMockAuthorizer("kim1");
+        AuthorizerDto authorizerDto = MockAuthorizer.getMockAuthorizer("kim1", 1L);
         //when
         SuiteRoom suiteRoom = suiteRoomRepository.findBySuiteRoomId(targetSuiteRoomId).orElseThrow(
                 () -> assertThrows(CustomException.class, () -> { throw new CustomException(StatusCode.NOT_FOUND); } )
@@ -72,7 +72,7 @@ class ParticipantServiceImplTest {
     public void removeParticipant() {
         //given
         Long targetSuiteRoomId = 1L;
-        AuthorizerDto authorizerDto = MockAuthorizer.getMockAuthorizer("kim1");
+        AuthorizerDto authorizerDto = MockAuthorizer.getMockAuthorizer("kim1", 1L);
         //when
         Participant participant = participantRepository.findBySuiteRoom_SuiteRoomIdAndMemberId(targetSuiteRoomId, authorizerDto.getMemberId()).orElseThrow(
                 () -> assertThrows(CustomException.class, () -> { throw new CustomException(StatusCode.FAILED_REQUEST); })

--- a/src/test/java/com/suite/suite_suite_room_service/suiteRoom/service/ParticipantServiceImplTest.java
+++ b/src/test/java/com/suite/suite_suite_room_service/suiteRoom/service/ParticipantServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.suite.suite_suite_room_service.suiteRoom.service;
 
+import com.suite.suite_suite_room_service.suiteRoom.dto.SuiteStatus;
 import com.suite.suite_suite_room_service.suiteRoom.entity.Participant;
 import com.suite.suite_suite_room_service.suiteRoom.entity.SuiteRoom;
 import com.suite.suite_suite_room_service.suiteRoom.handler.CustomException;
@@ -11,10 +12,12 @@ import com.suite.suite_suite_room_service.suiteRoom.repository.ParticipantReposi
 import com.suite.suite_suite_room_service.suiteRoom.repository.SuiteRoomRepository;
 import com.suite.suite_suite_room_service.suiteRoom.security.dto.AuthorizerDto;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -29,23 +32,26 @@ class ParticipantServiceImplTest {
     @Autowired private ParticipantRepository participantRepository;
     @Autowired private SuiteRoomRepository suiteRoomRepository;
 
+    private final SuiteRoom suiteRoom = MockSuiteRoom.getMockSuiteRoom("test", true).toSuiteRoomEntity();
+    private final Participant participantHost = MockParticipant.getMockParticipant(true, MockParticipant.getMockAuthorizer());
+
+    @BeforeEach
+    public void setUp() {
+        suiteRoom.addParticipant(participantHost);
+        suiteRoomRepository.save(suiteRoom);
+        participantRepository.save(participantHost);
+    }
 
     @Test
     @DisplayName("스위트룸 참가하기")
     public void addParticipant() {
         //given
-        SuiteRoom createSuiteRoom = MockSuiteRoom.getMockSuiteRoom("test", true).toSuiteRoomEntity();
-        Participant participantHost = MockParticipant.getMockParticipant(true, MockParticipant.getMockAuthorizer());
-        createSuiteRoom.addParticipant(participantHost);
-        suiteRoomRepository.save(createSuiteRoom);
-        participantRepository.save(participantHost);
-        Optional<SuiteRoom> enterRoom = suiteRoomRepository.findBySuiteRoomId(Long.parseLong("1"));
-        Long targetSuiteRoomId = enterRoom.get().getSuiteRoomId();
+        Long targetSuiteRoomId = 1L;
+        AuthorizerDto authorizerDto = MockAuthorizer.getMockAuthorizer("kim1");
         //when
         SuiteRoom suiteRoom = suiteRoomRepository.findBySuiteRoomId(targetSuiteRoomId).orElseThrow(
                 () -> assertThrows(CustomException.class, () -> { throw new CustomException(StatusCode.NOT_FOUND); } )
         );
-        AuthorizerDto authorizerDto = MockAuthorizer.getMockAuthorizer("kim1");
         participantRepository.findBySuiteRoom_SuiteRoomIdAndMemberId(targetSuiteRoomId, authorizerDto.getMemberId()).ifPresent(
                 participant -> { assertThrows(CustomException.class, () -> { throw new CustomException(StatusCode.ALREADY_EXISTS_PARTICIPANT); } );}
         );
@@ -59,6 +65,28 @@ class ParticipantServiceImplTest {
         );
     }
 
+
+    @Test
+    @DisplayName("스위트룸 참가 취소")
+    @Transactional
+    public void cancelParticipant() {
+        //given
+        Long targetSuiteRoomId = 1L;
+        AuthorizerDto authorizerDto = MockAuthorizer.getMockAuthorizer("kim1");
+        //when
+        Participant participant = participantRepository.findBySuiteRoom_SuiteRoomIdAndMemberId(targetSuiteRoomId, authorizerDto.getMemberId()).orElseThrow(
+                () -> assertThrows(CustomException.class, () -> { throw new CustomException(StatusCode.FAILED_REQUEST); })
+         );
+
+        if(participant.getStatus().equals(SuiteStatus.READY))
+            System.out.println("kafka");
+        participantRepository.deleteBySuiteRoom_SuiteRoomIdAndMemberId(targetSuiteRoomId, authorizerDto.getMemberId());
+        List<Participant> result = participantRepository.findBySuiteRoom_SuiteRoomId(targetSuiteRoomId);
+        //then
+        Assertions.assertAll(
+                () -> assertThat(result.size()).isEqualTo(1)
+        );
+    }
 
 
 }

--- a/src/test/java/com/suite/suite_suite_room_service/suiteRoom/service/ParticipantServiceImplTest.java
+++ b/src/test/java/com/suite/suite_suite_room_service/suiteRoom/service/ParticipantServiceImplTest.java
@@ -69,7 +69,7 @@ class ParticipantServiceImplTest {
     @Test
     @DisplayName("스위트룸 참가 취소")
     @Transactional
-    public void cancelParticipant() {
+    public void removeParticipant() {
         //given
         Long targetSuiteRoomId = 1L;
         AuthorizerDto authorizerDto = MockAuthorizer.getMockAuthorizer("kim1");

--- a/src/test/java/com/suite/suite_suite_room_service/suiteRoom/service/ParticipantServiceImplTest.java
+++ b/src/test/java/com/suite/suite_suite_room_service/suiteRoom/service/ParticipantServiceImplTest.java
@@ -75,8 +75,10 @@ class ParticipantServiceImplTest {
         AuthorizerDto authorizerDto = MockAuthorizer.getMockAuthorizer("kim1", 1L);
         //when
         Participant participant = participantRepository.findBySuiteRoom_SuiteRoomIdAndMemberId(targetSuiteRoomId, authorizerDto.getMemberId()).orElseThrow(
-                () -> assertThrows(CustomException.class, () -> { throw new CustomException(StatusCode.FAILED_REQUEST); })
-         );
+                () -> assertThrows(CustomException.class, () -> { throw new CustomException(StatusCode.FAILED_REQUEST); }));
+
+        if(participant.getIsHost())
+            assertThrows(CustomException.class, () -> { throw new CustomException(StatusCode.CAN_NOT_CALCEL_SUITEROOM); });
 
         if(participant.getStatus().equals(SuiteStatus.READY))
             System.out.println("kafka");


### PR DESCRIPTION
### 🗓️ PR 날짜 🗓️
<!-- YYYY/NN/DD -->
- 2023/08/03


### 🧐 구현 방법 🧐
<!-- 내용을 적어주세요 -->
- 스터디 참가 취소 처리 api 개발
- 먼저 참가자가 참여했는지 확인 한 후에 참가자의 상태가 READY인 경우 카프카통신을 해야하는데 일단 프린트문으로 처리하였음
- 그 후에 취소 처리를 함.

### 📸 API 명세서 사진 📸
<!-- 사진 첨부 -->
### 참가 취소 시
<img width="910" alt="image" src="https://github.com/SWM-TheDreaming/SUITE_SUITE_ROOM_SERVICE/assets/74559561/83caace8-fa67-4ec0-9b5c-f8c9befd3641">

### 참가 안했는데 취소 시
<img width="912" alt="image" src="https://github.com/SWM-TheDreaming/SUITE_SUITE_ROOM_SERVICE/assets/74559561/cc4369b9-a4de-4443-b93f-b6390e92a4b6">

### 방장이 참가 취소할 경우
<img width="908" alt="image" src="https://github.com/SWM-TheDreaming/SUITE_SUITE_ROOM_SERVICE/assets/74559561/08a9005d-aa68-4252-a0ed-945f664c1577">


### 테스트 코드
<img width="863" alt="image" src="https://github.com/SWM-TheDreaming/SUITE_SUITE_ROOM_SERVICE/assets/74559561/12bb8b2d-d76c-4a0d-b21a-606e70001d65">


### 실제 코드
<img width="846" alt="image" src="https://github.com/SWM-TheDreaming/SUITE_SUITE_ROOM_SERVICE/assets/74559561/d7c1d07a-f1b3-42a4-98fb-f268fbd4cb09">
