### PR TITLE
feat: 보증금납부 후 참가 Kafka 완료

### DIFF
--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/dto/ResAnpOfMemberDto.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/dto/ResAnpOfMemberDto.java
@@ -1,0 +1,18 @@
+package com.suite.suite_suite_room_service.suiteRoom.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ResAnpOfMemberDto {
+    private Long memberId;
+    private Integer point;
+
+    @Builder
+    public ResAnpOfMemberDto(Long memberId, Integer point) {
+        this.memberId = memberId;
+        this.point = point;
+    }
+}

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/handler/StatusCode.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/handler/StatusCode.java
@@ -19,6 +19,7 @@ public enum StatusCode {
     PLAIN_USER_EXIST(405, "포인트 결제중인 유저가 있습니다. 잠시 후 다시 시도하세요.", HttpStatus.METHOD_NOT_ALLOWED),
     IS_NOT_OPEN(400, "방장이 체크인을 완료하지 않은 스위트룸입니다.", HttpStatus.FORBIDDEN),
     UNAUTHORIZED (400, "로그인 후 이용가능합니다.", HttpStatus.UNAUTHORIZED),
+    FAILED_PAY(400, "포인트가 부족합니다.", HttpStatus.BAD_REQUEST),
     EXPIRED_JWT(400, "기존 토큰이 만료되었습니다. 해당 토큰을 가지고 /token/refresh 링크로 이동 후 토큰을 재발급 받으세요.", HttpStatus.UNAUTHORIZED),
     RE_LOGIN(400, "모든 토큰이 만료되었습니다. 다시 로그인해주세요.", HttpStatus.UNAUTHORIZED),
     FAILED_SIGNUP(400, "회원가입에 실패하였습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/kafka/config/KafkaConfig.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/kafka/config/KafkaConfig.java
@@ -1,0 +1,90 @@
+package com.suite.suite_suite_room_service.suiteRoom.kafka.config;
+
+import com.suite.suite_suite_room_service.suiteRoom.handler.CustomException;
+import com.suite.suite_suite_room_service.suiteRoom.service.AnpService;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.FixedBackOff;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@EnableKafka
+@Configuration
+public class KafkaConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String,Object> configs = new HashMap<>();
+        configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configs);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        // auto.commit 설정을 수동으로 변경
+        //configs.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false); // 자동 커밋 비활성화
+
+        // auto.offset.reset 설정을 수동으로 변경
+        //configs.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"); // 가장 초기 오프셋부터 시작
+        return new DefaultKafkaConsumerFactory<>(configs, new StringDeserializer(), new StringDeserializer());
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        //factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
+        factory.setConsumerFactory(consumerFactory());
+        factory.setCommonErrorHandler(errorHandler());
+        return factory;
+    }
+
+    @Bean
+    public DefaultErrorHandler errorHandler() {
+        DefaultErrorHandler errorHandler = new DefaultErrorHandler((consumerRecord, exception) -> {
+            log.error("[Error] topic = {}, key = {}, value = {}, offset = {}, error message = {}", consumerRecord.topic(),
+                    consumerRecord.key(), consumerRecord.value(), consumerRecord.offset(), exception.getMessage());
+
+        }, new FixedBackOff(1000L, 3)); // 1초 간격으로 최대 3번
+        errorHandler.addNotRetryableExceptions(CustomException.class);
+
+        return errorHandler;
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+
+    @Bean
+    public AnpService anpService(RestTemplate restTemplate) {
+        String GET_POINT_URI = "http://localhost:8088/anp/point/";
+        return new AnpService(GET_POINT_URI, restTemplate);
+    }
+}

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/kafka/consumer/SuiteRoomConsumer.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/kafka/consumer/SuiteRoomConsumer.java
@@ -1,0 +1,60 @@
+package com.suite.suite_suite_room_service.suiteRoom.kafka.consumer;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.suite.suite_suite_room_service.suiteRoom.dto.SuiteStatus;
+import com.suite.suite_suite_room_service.suiteRoom.entity.Participant;
+import com.suite.suite_suite_room_service.suiteRoom.entity.SuiteRoom;
+import com.suite.suite_suite_room_service.suiteRoom.handler.CustomException;
+import com.suite.suite_suite_room_service.suiteRoom.handler.StatusCode;
+import com.suite.suite_suite_room_service.suiteRoom.repository.ParticipantRepository;
+import com.suite.suite_suite_room_service.suiteRoom.repository.SuiteRoomRepository;
+import com.suite.suite_suite_room_service.suiteRoom.security.dto.AuthorizerDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class SuiteRoomConsumer {
+    private final SuiteRoomRepository suiteRoomRepository;
+    private final ParticipantRepository participantRepository;
+
+    @Transactional
+    @KafkaListener(topics = "${topic.SUITEROOM_JOIN}", groupId = "suite", containerFactory = "kafkaListenerContainerFactory")
+    public void userRegistrationFCMConsume(ConsumerRecord<String, String> record) throws IOException, ParseException {
+        JSONParser parser = new JSONParser();
+        ObjectMapper objectMapper = new ObjectMapper();
+        JSONObject jsonObject = (JSONObject) parser.parse(record.value());
+        JSONObject data = ((JSONObject) jsonObject.get("data"));
+        Long suiteRoomId = Long.parseLong(data.get("suiteRoomId").toString());
+        boolean isHost = Boolean.parseBoolean(data.get("isHost").toString());
+        JSONObject authorizerDtoObject = ((JSONObject) data.get("authorizerDto"));
+        AuthorizerDto authorizerDto = objectMapper.readValue(authorizerDtoObject.toString(), AuthorizerDto.class);
+
+        addParticipant(suiteRoomId, isHost, authorizerDto);
+    }
+
+
+
+    private void addParticipant(Long suiteRoomId, boolean isHost, AuthorizerDto authorizerDto) {
+        SuiteRoom suiteRoom = suiteRoomRepository.findBySuiteRoomId(suiteRoomId).get();
+
+        Participant participant = Participant.builder()
+                .authorizerDto(authorizerDto)
+                .status(SuiteStatus.READY)
+                .isHost(isHost).build();
+        suiteRoom.addParticipant(participant);
+
+        participantRepository.save(participant);
+    }
+}

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/kafka/producer/SuiteRoomProducer.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/kafka/producer/SuiteRoomProducer.java
@@ -1,0 +1,50 @@
+package com.suite.suite_suite_room_service.suiteRoom.kafka.producer;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.suite.suite_suite_room_service.suiteRoom.entity.SuiteRoom;
+import com.suite.suite_suite_room_service.suiteRoom.security.dto.AuthorizerDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.json.simple.JSONObject;
+import org.json.simple.JSONValue;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class SuiteRoomProducer {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    @Value("${topic.DEPOSIT_PAYMENT}") private String DEPOSIT_PAYMENT;
+
+    public void sendPaymentMessage(SuiteRoom suiteRoom, AuthorizerDto authorizerDto, boolean isHost) {
+        Map<String, Object> data = payDepositAmount(suiteRoom, authorizerDto, isHost);
+        log.info("SuiteRoom-Join message : {}", data);
+        JSONObject obj = new JSONObject();
+        obj.put("uuid", "SuiteRoomProducer/" + Instant.now().toEpochMilli());
+        obj.put("data", data);
+        this.kafkaTemplate.send(DEPOSIT_PAYMENT, obj.toJSONString());
+    }
+
+    private Map<String, Object> payDepositAmount(SuiteRoom suiteRoom, AuthorizerDto authorizerDto, boolean isHost) {
+        try {
+            Map<String, Object> map = new HashMap<>();
+            JSONObject parsedObject = (JSONObject) JSONValue.parse(authorizerDto.toJSONString());
+            map.put("suiteRoomId", suiteRoom.getSuiteRoomId());
+            map.put("authorizerDto", parsedObject);
+            map.put("depositAmount", suiteRoom.getDepositAmount());
+            map.put("isHost", isHost);
+            return map;
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/security/dto/AuthorizerDto.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/security/dto/AuthorizerDto.java
@@ -1,5 +1,8 @@
 package com.suite.suite_suite_room_service.suiteRoom.security.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,6 +11,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class AuthorizerDto {
+
     private Long memberId;
     private String email;
     private String name;
@@ -35,5 +39,10 @@ public class AuthorizerDto {
         ACCOUNTSTATUS("ACCOUNTSTATUS"),
         ROLE("ROLE");
         private final String value;
+    }
+
+    public String toJSONString() throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.writeValueAsString(this);
     }
 }

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/service/AnpService.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/service/AnpService.java
@@ -1,0 +1,25 @@
+package com.suite.suite_suite_room_service.suiteRoom.service;
+
+import com.suite.suite_suite_room_service.suiteRoom.dto.ResAnpOfMemberDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Objects;
+
+public class AnpService {
+    private final String ANP_POINT_URI;
+    private final RestTemplate restTemplate;
+
+    public AnpService(String ANP_POINT_URI, RestTemplate restTemplate) {
+        this.ANP_POINT_URI = ANP_POINT_URI;
+        this.restTemplate = restTemplate;
+    }
+
+
+    public int getPoint(Long memberId) {
+        String url = ANP_POINT_URI + memberId;
+        ResponseEntity<ResAnpOfMemberDto> anpOfMemberDto = restTemplate.getForEntity(url, ResAnpOfMemberDto.class);
+        return Objects.requireNonNull(anpOfMemberDto.getBody()).getPoint();
+
+    }
+}

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/service/SuiteRoomServiceImpl.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/service/SuiteRoomServiceImpl.java
@@ -6,26 +6,29 @@ import com.suite.suite_suite_room_service.suiteRoom.entity.SuiteRoom;
 import com.suite.suite_suite_room_service.suiteRoom.handler.CustomException;
 import com.suite.suite_suite_room_service.suiteRoom.handler.StatusCode;
 
+import com.suite.suite_suite_room_service.suiteRoom.kafka.producer.SuiteRoomProducer;
 import com.suite.suite_suite_room_service.suiteRoom.repository.ParticipantRepository;
 import com.suite.suite_suite_room_service.suiteRoom.repository.SuiteRoomRepository;
-import com.suite.suite_suite_room_service.suiteRoom.security.AuthorizationJwtCreator;
 import com.suite.suite_suite_room_service.suiteRoom.security.dto.AuthorizerDto;
 
 import lombok.RequiredArgsConstructor;
 
+import org.json.simple.JSONObject;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
+import java.time.Instant;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class SuiteRoomServiceImpl implements SuiteRoomService{
+
     private final SuiteRoomRepository suiteRoomRepository;
     private final ParticipantRepository participantRepository;
+    private final SuiteRoomProducer suiteRoomProducer;
+    private final AnpService anpService;
 
 
     @Override
@@ -68,19 +71,20 @@ public class SuiteRoomServiceImpl implements SuiteRoomService{
     }
 
     @Override
+    @Transactional
     public void createSuiteRoom(ReqSuiteRoomDto reqSuiteRoomDto, AuthorizerDto authorizerDto) {
         suiteRoomRepository.findByTitle(reqSuiteRoomDto.getTitle()).ifPresent(
                 suiteRoom ->  { throw new CustomException(StatusCode.ALREADY_EXISTS_SUITEROOM); }
         );
         SuiteRoom suiteRoom = reqSuiteRoomDto.toSuiteRoomEntity();
-        Participant participant = Participant.builder()
-                                        .authorizerDto(authorizerDto)
-                                        .status(SuiteStatus.PLAIN)
-                                        .isHost(true).build();
-        suiteRoom.addParticipant(participant);
+
+        if(anpService.getPoint(authorizerDto.getMemberId()) < suiteRoom.getDepositAmount())
+            throw new CustomException(StatusCode.FAILED_PAY);
 
         suiteRoomRepository.save(suiteRoom);
-        participantRepository.save(participant);
+        suiteRoomProducer.sendPaymentMessage(suiteRoom, authorizerDto, true);
+
+
     }
 
 
@@ -108,6 +112,11 @@ public class SuiteRoomServiceImpl implements SuiteRoomService{
         suiteRoom.updateSuiteRoom(reqUpdateSuiteRoomDto);
     }
 
-
+    private String generateJSONData(Object data) {
+        JSONObject obj = new JSONObject();
+        obj.put("uuid", "SuiteRoomProducer/" + Instant.now().toEpochMilli());
+        obj.put("data", data);
+        return obj.toJSONString();
+    }
 
 }


### PR DESCRIPTION
### 🗓️ PR 날짜 🗓️
<!-- YYYY/NN/DD -->
- 2023/09/04


### 🧐 구현 방법 🧐
<!-- 내용을 적어주세요 -->
- 해당하는 토픽에 결제요청 시 AnPSvc에서 포인트 차감후 Join토픽으로 메시지 프로듀싱한 뒤 Paticipant에 Ready상태로 데이터 저장

# ❗️anp_of_member 테이블에서 포인트 지급 후 테스트 해야함

### 📸 API 명세서 사진 📸
<!-- 사진 첨부 -->
### 실제 코드

### 결제요청 메시지를 프로듀싱하는 코드
<img width="961" alt="image" src="https://github.com/SWM-TheDreaming/SUITE_SUITE_ROOM_SERVICE/assets/74559561/3afbcae1-27c9-4099-bf78-b6b94d25687f">

### AnPSvc로부터 포인트 차감이 이루어진 뒤 Join 토픽 메시지를 컨슘하는 코드
<img width="969" alt="image" src="https://github.com/SWM-TheDreaming/SUITE_SUITE_ROOM_SERVICE/assets/74559561/8e61cf31-b069-4366-a565-e25c356df942">

### AnPSvc에게 Point 얼마남았는지 보내는 요청 RestTemplate로 뺴고 Bean 등록
<img width="585" alt="image" src="https://github.com/SWM-TheDreaming/SUITE_SUITE_ROOM_SERVICE/assets/74559561/95fa0c50-1d24-4e46-b827-b45e46450701">

### Bean등록한 AnpService 코드
<img width="977" alt="image" src="https://github.com/SWM-TheDreaming/SUITE_SUITE_ROOM_SERVICE/assets/74559561/49582607-4131-4aab-81b6-9f0326b1efce">
