### PR TITLE
S UI t 83 스터디 그룹 시작 카프카

### DIFF
--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/controller/ParticipantController.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/controller/ParticipantController.java
@@ -30,7 +30,7 @@ public class ParticipantController {
 
     @PostMapping("/suiteroom/beginning")
     public ResponseEntity<Message> startSuiteRoom(@RequestBody Map<String, Long> suiteRoomId) {
-        participantService.updateParticipantsStatusReadyToStart(suiteRoomId.get("suiteRoomId"));
+        participantService.updateParticipantsStatusReadyToStart(suiteRoomId.get("suiteRoomId"), getSuiteAuthorizer().getMemberId());
         return ResponseEntity.ok(new Message(StatusCode.OK));
     }
 

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/controller/SuiteRoomController.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/controller/SuiteRoomController.java
@@ -42,6 +42,7 @@ public class SuiteRoomController {
         return ResponseEntity.ok(new Message(StatusCode.OK, getSuiteRoom));
     }
 
+
     @GetMapping("/progression")
     public ResponseEntity<Message> listUpProgressionRooms() {
         return null;
@@ -69,10 +70,7 @@ public class SuiteRoomController {
         return ResponseEntity.ok(new Message(StatusCode.OK));
     }
 
-    @PostMapping("/suiteroom/attendance")
-    public ResponseEntity<Message> attendanceRoom() {
-        return null;
-    }
+
     @DeleteMapping("/suiteroom/delete/{suiteRoomId}")
     public ResponseEntity<Message> deleteRoom(@PathVariable Long suiteRoomId) {
         suiteRoomService.deleteSuiteRoom(suiteRoomId, getSuiteAuthorizer());

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/dto/ReqSuiteRoomDto.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/dto/ReqSuiteRoomDto.java
@@ -24,12 +24,13 @@ public class ReqSuiteRoomDto {
     private Boolean isPublic;
     private Integer password;
     private Boolean isOpen;
+    private Boolean isStart;
     private String channelLink;
     private StudyType studyMethod;
     private String contractAddress;
 
     @Builder
-    public ReqSuiteRoomDto(String title, String content, StudyCategory subject, Timestamp recruitmentDeadline, Timestamp studyDeadline, Integer recruitmentLimit, Integer depositAmount, Integer minAttendanceRate, Integer minMissionCompleteRate, Boolean isPublic, Integer password, Boolean isOpen, String channelLink, StudyType studyMethod, String contractAddress) {
+    public ReqSuiteRoomDto(String title, String content, StudyCategory subject, Timestamp recruitmentDeadline, Timestamp studyDeadline, Integer recruitmentLimit, Integer depositAmount, Integer minAttendanceRate, Integer minMissionCompleteRate, Boolean isPublic, Integer password, Boolean isOpen, Boolean isStart, String channelLink, StudyType studyMethod, String contractAddress) {
         this.title = title;
         this.content = content;
         this.subject = subject;
@@ -42,6 +43,7 @@ public class ReqSuiteRoomDto {
         this.isPublic = isPublic;
         this.password = password;
         this.isOpen = isOpen;
+        this.isStart = isStart;
         this.channelLink = channelLink;
         this.studyMethod = studyMethod;
         this.contractAddress = contractAddress;
@@ -61,6 +63,7 @@ public class ReqSuiteRoomDto {
                 .isPublic(isPublic)
                 .password(password)
                 .isOpen(isOpen)
+                .isStart(false)
                 .channelLink(channelLink)
                 .studyMethod(studyMethod)
                 .contractAddress(contractAddress).build();

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/dto/ResPaymentParticipantDto.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/dto/ResPaymentParticipantDto.java
@@ -1,5 +1,6 @@
 package com.suite.suite_suite_room_service.suiteRoom.dto;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,12 +8,14 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class ResPaymentParticipantDto {
+    private Long memberId;
     private String nickName;
     private String email;
     private SuiteStatus status;
     private boolean isHost;
     @Builder
-    public ResPaymentParticipantDto(String nickName, String email, SuiteStatus status, boolean isHost) {
+    public ResPaymentParticipantDto(Long memberId, String nickName, String email, SuiteStatus status, boolean isHost) {
+        this.memberId = memberId;
         this.nickName = nickName;
         this.email = email;
         this.status = status;

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/entity/Participant.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/entity/Participant.java
@@ -63,6 +63,7 @@ public class Participant extends BaseTimeEntity {
 
     public ResPaymentParticipantDto toResPaymentParticipantDto() {
         return ResPaymentParticipantDto.builder()
+                .memberId(this.memberId)
                 .nickName(this.nickname)
                 .email(this.email)
                 .status(this.status)

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/entity/Participant.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/entity/Participant.java
@@ -8,12 +8,14 @@ import com.suite.suite_suite_room_service.suiteRoom.security.dto.AuthorizerDto;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.*;
 
 @Entity
 @Getter
 @NoArgsConstructor
+@DynamicUpdate
 @Table(name = "participant")
 public class Participant extends BaseTimeEntity {
     @Id

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/entity/SuiteRoom.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/entity/SuiteRoom.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicUpdate;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.*;
 import java.sql.Timestamp;
@@ -114,7 +115,11 @@ public class SuiteRoom extends BaseTimeEntity {
         this.isOpen = true;
     }
 
-    public void startSuiteRoom() { this.isStart = true; }
+    public void startSuiteRoom() {
+        this.isStart = true;
+    }
+
+    public void startErrorSuiteRoom() { this.isStart = false; }
 
     public ResSuiteRoomListDto toResSuiteRoomListDto(Long participantCount, boolean isHost, Participant participant, Long markCount) {
         return ResSuiteRoomListDto.builder()

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/entity/SuiteRoom.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/entity/SuiteRoom.java
@@ -62,6 +62,9 @@ public class SuiteRoom extends BaseTimeEntity {
     @Column(name = "is_open")
     private Boolean isOpen;
 
+    @Column(name = "is_start")
+    private Boolean isStart;
+
     @Column(name = "channel_link")
     private String channelLink;
 
@@ -77,7 +80,7 @@ public class SuiteRoom extends BaseTimeEntity {
     private List<Participant> participants = new ArrayList<>();
 
     @Builder
-    public SuiteRoom(Long suiteRoomId, String title, String content, StudyCategory subject, Timestamp recruitmentDeadline, Timestamp studyDeadline, Integer recruitmentLimit, Integer depositAmount, Integer minAttendanceRate, Integer minMissionCompleteRate, Boolean isPublic, Integer password, Boolean isOpen, String channelLink, StudyType studyMethod, String contractAddress, Long participantId) {
+    public SuiteRoom(Long suiteRoomId, String title, String content, StudyCategory subject, Timestamp recruitmentDeadline, Timestamp studyDeadline, Integer recruitmentLimit, Integer depositAmount, Integer minAttendanceRate, Integer minMissionCompleteRate, Boolean isPublic, Integer password, Boolean isOpen, Boolean isStart, String channelLink, StudyType studyMethod, String contractAddress, Long participantId) {
         this.suiteRoomId = suiteRoomId;
         this.title = title;
         this.content = content;
@@ -91,6 +94,7 @@ public class SuiteRoom extends BaseTimeEntity {
         this.isPublic = isPublic;
         this.password = password;
         this.isOpen = isOpen;
+        this.isStart = isStart;
         this.channelLink = channelLink;
         this.studyMethod = studyMethod;
         this.contractAddress = contractAddress;
@@ -109,6 +113,8 @@ public class SuiteRoom extends BaseTimeEntity {
     public void openSuiteRoom() {
         this.isOpen = true;
     }
+
+    public void startSuiteRoom() { this.isStart = true; }
 
     public ResSuiteRoomListDto toResSuiteRoomListDto(Long participantCount, boolean isHost, Long markCount) {
         return ResSuiteRoomListDto.builder()

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/handler/StatusCode.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/handler/StatusCode.java
@@ -10,6 +10,7 @@ public enum StatusCode {
     DORMANT_ACCOUNT(423, "이 계정은 휴먼 계정입니다.", HttpStatus.LOCKED),
     ALREADY_EXISTS_SUITEROOM(400, "이미 존재하는 스위트룸입니다.", HttpStatus.BAD_REQUEST),
     ALREADY_EXISTS_PARTICIPANT(400, "이미 참여중 입니다.", HttpStatus.BAD_REQUEST),
+    ALEADY_START_OR_NOT_FOUND(400, "이미 시작되었거나 없는 방입니다.", HttpStatus.BAD_REQUEST),
     CAN_NOT_CALCEL_SUITEROOM(400, "스위트룸 참가 취소를 할 수 없습니다.", HttpStatus.BAD_REQUEST),
     NOT_DELETE_SUITE_ROOM(400, "시작된 스터디는 삭제가 불가능합니다.", HttpStatus.BAD_REQUEST),
     USERNAME_OR_PASSWORD_NOT_FOUND (400, "아이디 또는 비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/kafka/config/KafkaConfig.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/kafka/config/KafkaConfig.java
@@ -75,6 +75,13 @@ public class KafkaConfig {
     }
 
     @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerDefaultContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+
+    @Bean
     public DefaultErrorHandler slackErrorHandler() {
         DefaultErrorHandler errorHandler = new DefaultErrorHandler((consumerRecord, exception) -> {
             log.error("[Error] topic = {}, key = {}, value = {}, error message = {}", consumerRecord.topic(),

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/kafka/producer/SuiteRoomProducer.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/kafka/producer/SuiteRoomProducer.java
@@ -14,6 +14,7 @@ import com.suite.suite_suite_room_service.suiteRoom.handler.StatusCode;
 import com.suite.suite_suite_room_service.suiteRoom.security.dto.AuthorizerDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 import org.springframework.beans.factory.annotation.Value;
@@ -64,7 +65,7 @@ public class SuiteRoomProducer {
         try {
             Map<String, Object> map = new HashMap<>();
             ObjectMapper objectMapper = new ObjectMapper();
-            JSONObject parsedObject = (JSONObject) JSONValue.parse(objectMapper.writeValueAsString(resPaymentParticipantDtos));
+            JSONArray parsedObject = (JSONArray) JSONValue.parse(objectMapper.writeValueAsString(resPaymentParticipantDtos));
             map.put("suiteRoomId", suiteRoom.getSuiteRoomId());
             map.put("depositAmount", suiteRoom.getDepositAmount());
             map.put("minAttendanceRate", suiteRoom.getMinAttendanceRate());

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/kafka/producer/SuiteRoomProducer.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/kafka/producer/SuiteRoomProducer.java
@@ -38,6 +38,7 @@ public class SuiteRoomProducer {
     @Value("${topic.SUITEROOM_CONTRACT_CREATION}") private String SUITEROOM_CONTRACT_CREATION;
     @Value("${topic.SUITEROOM_CANCELJOIN}") private String SUITEROOM_CANCELJOIN;
     @Value("${topic.DEPOSIT_PAYMENT}") private String DEPOSIT_PAYMENT;
+    @Value("${topic.SUITEROOM_START}") private String SUITEROOM_START;
     private final KafkaTemplate<String, String> kafkaTemplate;
 
 
@@ -51,6 +52,28 @@ public class SuiteRoomProducer {
         Map<String, Object> data = updateStatusReadyToStart(suiteRoomId, participants, suiteRoom);
         log.info("SuiteRoom-Contract-Creation message : {}", data);
         this.kafkaTemplate.send(SUITEROOM_CONTRACT_CREATION, makeMessage(data));
+    }
+
+    public void suiteRoomStartProducer(SuiteRoom suiteRoom, List<ResPaymentParticipantDto> resPaymentParticipantDtos) {
+        Map<String, Object> data = startSuiteRoom(suiteRoom, resPaymentParticipantDtos);
+        log.info("SuiteRoom-Start message : {}", data);
+        this.kafkaTemplate.send(SUITEROOM_START, makeMessage(data));
+    }
+
+    private Map<String, Object> startSuiteRoom(SuiteRoom suiteRoom, List<ResPaymentParticipantDto> resPaymentParticipantDtos) {
+        try {
+            Map<String, Object> map = new HashMap<>();
+            ObjectMapper objectMapper = new ObjectMapper();
+            JSONObject parsedObject = (JSONObject) JSONValue.parse(objectMapper.writeValueAsString(resPaymentParticipantDtos));
+            map.put("suiteRoomId", suiteRoom.getSuiteRoomId());
+            map.put("depositAmount", suiteRoom.getDepositAmount());
+            map.put("minAttendanceRate", suiteRoom.getMinAttendanceRate());
+            map.put("minMissionCompleteRate", suiteRoom.getMinMissionCompleteRate());
+            map.put("participants", parsedObject);
+            return map;
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
     }
 
 

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/kafka/producer/SuiteRoomProducer.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/kafka/producer/SuiteRoomProducer.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.suite.suite_suite_room_service.suiteRoom.dto.ResPaymentParticipantDto;
 import com.suite.suite_suite_room_service.suiteRoom.dto.ResSuiteRoomDto;
-import com.suite.suite_suite_room_service.suiteRoom.dto.ResSuiteRoomListDto;
 import com.suite.suite_suite_room_service.suiteRoom.dto.SuiteStatus;
 import com.suite.suite_suite_room_service.suiteRoom.entity.Participant;
 import com.suite.suite_suite_room_service.suiteRoom.entity.SuiteRoom;
@@ -65,8 +64,10 @@ public class SuiteRoomProducer {
         try {
             Map<String, Object> map = new HashMap<>();
             ObjectMapper objectMapper = new ObjectMapper();
+            System.out.println("@ : " + suiteRoom.getIsStart());
             JSONArray parsedObject = (JSONArray) JSONValue.parse(objectMapper.writeValueAsString(resPaymentParticipantDtos));
             map.put("suiteRoomId", suiteRoom.getSuiteRoomId());
+            map.put("suiteRoomTitle", suiteRoom.getTitle());
             map.put("depositAmount", suiteRoom.getDepositAmount());
             map.put("minAttendanceRate", suiteRoom.getMinAttendanceRate());
             map.put("minMissionCompleteRate", suiteRoom.getMinMissionCompleteRate());

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/repository/SuiteRoomRepository.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/repository/SuiteRoomRepository.java
@@ -15,6 +15,8 @@ public interface SuiteRoomRepository extends JpaRepository<SuiteRoom, Long> {
     Page<SuiteRoom> findByIsOpenAndSubjectInOrderByCreatedDateDesc(boolean isOpen, List<StudyCategory> subject, Pageable pageable);
     Page<SuiteRoom> findByIsOpenOrderByCreatedDateDesc(boolean isOpen, Pageable pageable);
     Optional<SuiteRoom> findByTitle(String title);
+    Optional<SuiteRoom> findBySuiteRoomIdAndIsStart(Long suiteRoomId, boolean isStart);
+
     Optional<SuiteRoom> findBySuiteRoomId(Long suiteRoomId);
     void deleteBySuiteRoomId(Long suiteRoomId);
 

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/service/ParticipantService.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/service/ParticipantService.java
@@ -16,6 +16,6 @@ public interface ParticipantService {
 
     List<ResPaymentParticipantDto> listUpNotYetPaymentParticipants(Long suiteRoomId);
 
-    void updateParticipantsStatusReadyToStart(Long suiteRoomId);
+    void updateParticipantsStatusReadyToStart(Long suiteRoomId, Long memberId);
 
 }

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/service/ParticipantService.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/service/ParticipantService.java
@@ -16,6 +16,6 @@ public interface ParticipantService {
 
     List<ResPaymentParticipantDto> listUpNotYetPaymentParticipants(Long suiteRoomId);
 
-    List<ResPaymentParticipantDto> updateParticipantsStatusReadyToStart(Long suiteRoomId);
+    void updateParticipantsStatusReadyToStart(Long suiteRoomId);
 
 }

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/service/ParticipantServiceImpl.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/service/ParticipantServiceImpl.java
@@ -117,14 +117,13 @@ public class ParticipantServiceImpl implements ParticipantService{
 
     @Override
     @Transactional
-    public void updateParticipantsStatusReadyToStart(Long suiteRoomId) {
+    public void updateParticipantsStatusReadyToStart(Long suiteRoomId, Long memberId) {
+        participantRepository.findBySuiteRoom_SuiteRoomIdAndMemberIdAndIsHost(suiteRoomId, memberId, true).orElseThrow(() -> new CustomException(StatusCode.FORBIDDEN));
         List<Participant> participants = participantRepository.findAllBySuiteRoom_SuiteRoomIdAndStatus(suiteRoomId, SuiteStatus.READY);
 
-        SuiteRoom suiteRoom = suiteRoomRepository.findBySuiteRoomId(suiteRoomId)
-                .orElseThrow(() ->  new CustomException(StatusCode.NOT_FOUND));
-
+        SuiteRoom suiteRoom = suiteRoomRepository.findBySuiteRoomIdAndIsStart(suiteRoomId, false)
+                .orElseThrow(() ->  new CustomException(StatusCode.ALEADY_START_OR_NOT_FOUND));
         suiteRoom.startSuiteRoom();
-
         List<ResPaymentParticipantDto> resPaymentParticipantDtos = participants.stream().map(
                 p -> {
                     p.updateStatus(SuiteStatus.START);

--- a/src/main/java/com/suite/suite_suite_room_service/suiteRoom/service/ParticipantServiceImpl.java
+++ b/src/main/java/com/suite/suite_suite_room_service/suiteRoom/service/ParticipantServiceImpl.java
@@ -103,6 +103,10 @@ public class ParticipantServiceImpl implements ParticipantService{
 
     @Override
     public List<ResPaymentParticipantDto> listUpNotYetPaymentParticipants(Long suiteRoomId) {
+
+        SuiteRoom suiteRoom = suiteRoomRepository.findBySuiteRoomId(suiteRoomId).orElseThrow(
+                () -> new CustomException(StatusCode.NOT_FOUND));
+
         List<ResPaymentParticipantDto> resPaymentParticipantDtos = participantRepository.findAllBySuiteRoom_SuiteRoomIdAndStatus(suiteRoomId, SuiteStatus.PLAIN)
                 .stream().map(
                         participant -> participant.toResPaymentParticipantDto()
@@ -113,17 +117,23 @@ public class ParticipantServiceImpl implements ParticipantService{
 
     @Override
     @Transactional
-    public List<ResPaymentParticipantDto> updateParticipantsStatusReadyToStart(Long suiteRoomId) {
+    public void updateParticipantsStatusReadyToStart(Long suiteRoomId) {
         List<Participant> participants = participantRepository.findAllBySuiteRoom_SuiteRoomIdAndStatus(suiteRoomId, SuiteStatus.READY);
-        SuiteRoom suiteRoom = suiteRoomRepository.findBySuiteRoomId(suiteRoomId)
-                .orElseThrow(() -> { throw new CustomException(StatusCode.NOT_FOUND); });
-        suiteRoomProducer.suiteRoomContractCreationProducer(suiteRoomId, participants, suiteRoom);
 
-        return participants.stream().map(
+        SuiteRoom suiteRoom = suiteRoomRepository.findBySuiteRoomId(suiteRoomId)
+                .orElseThrow(() ->  new CustomException(StatusCode.NOT_FOUND));
+
+        suiteRoom.startSuiteRoom();
+
+        List<ResPaymentParticipantDto> resPaymentParticipantDtos = participants.stream().map(
                 p -> {
                     p.updateStatus(SuiteStatus.START);
                     return p.toResPaymentParticipantDto();
                 }).collect(Collectors.toList());
+
+        //suiteRoomProducer.suiteRoomContractCreationProducer(suiteRoomId, participants, suiteRoom);
+
+        suiteRoomProducer.suiteRoomStartProducer(suiteRoom, resPaymentParticipantDtos);
     }
 
 }


### PR DESCRIPTION
### 🗓️ PR 날짜 🗓️
<!-- YYYY/NN/DD -->
- 2023/09/12


### 🧐 구현 방법 🧐
<!-- 내용을 적어주세요 -->
- 스위트룸 시작 시 스터디 서비스 대쉬보드로 participant 데이터 전송

### 📸 API 명세서 사진 📸
<!-- 사진 첨부 -->
### 실제 코드
### 스위트룸 시작 시 아래 메서드 호출
<img width="789" alt="image" src="https://github.com/SWM-TheDreaming/SUITE_SUITE_ROOM_SERVICE/assets/74559561/1ead1607-0745-433b-8080-2b847eceacd7">

### Producer로 스터디 서비스에게 카프카 데이터 전달
*해당 부분에서 JSONArray를 objectMapper.writeValueAsString()로 변환하면 "\ 문자가 들어가므로 아예 JSONArray로 전달하여 해결
<img width="1003" alt="image" src="https://github.com/SWM-TheDreaming/SUITE_SUITE_ROOM_SERVICE/assets/74559561/539829da-a890-4e7a-b584-ad24d5a0b854">

### SuiteRoomStart가 Error발생시 Consume 부분 RollBack 진행
<img width="939" alt="image" src="https://github.com/SWM-TheDreaming/SUITE_SUITE_ROOM_SERVICE/assets/74559561/0d20c1ac-89da-4f90-aaf2-6364e28b0881">
